### PR TITLE
Add TestDisableDuplicateCheck to test the disableDuplicateCheck trans…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@
 /node_modules
 /configuration
 /public/dist
-
+/npm-debug.log

--- a/public/README.md
+++ b/public/README.md
@@ -1,12 +1,16 @@
 # Adding a new Test
 
+Before you begin, run webpack from the working directory to incorporate your JavaScript changes:
+
+    webpack --watch
+
 ## Create The Test To Include
 
-1.  Create a javascript file, and place it into the `public/tests/` directory, prefix the name with `Test`.  Example: 
+1.  Create a javascript file, and place it into the `public/tests/` directory, prefix the name with `Test`.  Example:
 
         public/tests/TestShowMessage.js
 
-2.  Write the test.  All that is required is the addition of a function to the TestBase object.  Example: 
+2.  Write the test.  All that is required is the addition of a function to the TestBase object.  Example:
 
         File: public/tests/TestShowMessage.js
         -----------------------------------------------------------------------------------------
@@ -28,13 +32,13 @@ This will allow you to run a very simple test.  If you want to test clover conne
         var ExampleCloverConnectorListener = require("../ExampleCloverConnectorListener.js");
 
 2.  Create the extension to the class.  Accept the `cloverConnector` parameter and the `progressinfoCallback`.  Ensure that the prototype for the object and the constructor are properly set up.  Example:
-        
+
         var ShowMessageExampleCloverConnectorListener = function (cloverConnector, progressinfoCallback) {
             ExampleCloverConnectorListener.call(this, cloverConnector, progressinfoCallback);
             this.cloverConnector = cloverConnector;
             this.progressinfoCallback = progressinfoCallback;
         };
-        
+
         ShowMessageExampleCloverConnectorListener.prototype = Object.create(ExampleCloverConnectorListener.prototype);
         ShowMessageExampleCloverConnectorListener.prototype.constructor = ShowMessageExampleCloverConnectorListener;
 
@@ -55,22 +59,22 @@ This will allow you to run a very simple test.  If you want to test clover conne
                 this.testComplete(true);
             }.bind(this), 5000);
         };
-        
+
 4.  Add the function override that helps identify the test for display output.
 
         ShowMessageExampleCloverConnectorListener.prototype.getTestName = function () {
             return "Test Displaying a message on the device";
         };
-    
+
 5.  Create the new extension of the `TestBase`.  This tells the test about your ICloverConnectorListener.
 
         TestShowMessage = function (configUrl, friendlyName, progressinfoCallback) {
             TestBase.call(this, configUrl, friendlyName, progressinfoCallback);
         };
-        
+
         TestShowMessage.prototype = Object.create(TestBase.prototype);
         TestShowMessage.prototype.constructor = TestShowMessage;
-        
+
         TestShowMessage.prototype.getCloverConnectorListener = function (cloverConnector) {
             return new ShowMessageExampleCloverConnectorListener(cloverConnector, this.progressinfoCallback);
         };
@@ -83,5 +87,3 @@ This will allow you to run a very simple test.  If you want to test clover conne
         };
 
 There may be additional steps in the flow depending on the functionality being tested.  For more complex tests, look at `public/tests/TestSale.js`, `public/tests/TestAuth.js`, `public/tests/TestPreAuth.js` as well as the other tests in this directory.
- 
- 

--- a/public/js/index.html
+++ b/public/js/index.html
@@ -78,6 +78,8 @@
       <button class="btn brk test-btn" data-test="TestBadReject">Test sending an invalid payment in to reject. Fails on device.</button><br/>
       <button class="btn brk test-btn" data-test="TestBadSigVerify">1 Test sending an invalid payment in verify signature. Fails on device.</button><br/>
       <button class="btn brk test-btn" data-test="TestBadSigVerify2">2 Test sending an invalid payment in verify signature. Fails on device.</button><br/>
+      <button class="btn brk test-btn" data-test="TestDisableDuplicateCheck">Test the disableDuplicateCheck transaction setting (run this twice).</button><br/>
+
     </div>
 
     <script src="../built/common.js"></script>

--- a/public/js/tests/TestDisableDuplicateCheck.js
+++ b/public/js/tests/TestDisableDuplicateCheck.js
@@ -1,0 +1,83 @@
+var sdk = require('remote-pay-cloud-api');
+var ExampleCloverConnectorListener = require("../ExampleCloverConnectorListener.js");
+var clover = require("remote-pay-cloud");
+var TestBase = require("../TestBase.js");
+
+/**
+ * A test of the disableDuplicateCheck transaction setting on a SaleRequest.
+ *
+ * @type {DisableDuplicateCheckExampleCloverConnectorListener}
+ */
+var DisableDuplicateCheckExampleCloverConnectorListener = function (cloverConnector, progressinfoCallback) {
+    ExampleCloverConnectorListener.call(this, cloverConnector, progressinfoCallback);
+    this.cloverConnector = cloverConnector;
+    this.progressinfoCallback = progressinfoCallback;
+};
+
+DisableDuplicateCheckExampleCloverConnectorListener.prototype = Object.create(ExampleCloverConnectorListener.prototype);
+DisableDuplicateCheckExampleCloverConnectorListener.prototype.constructor = DisableDuplicateCheckExampleCloverConnectorListener;
+
+DisableDuplicateCheckExampleCloverConnectorListener.prototype.startTest = function () {
+    ExampleCloverConnectorListener.prototype.startTest.call(this);
+    /*
+     The connector is ready, create a sale request with disableDuplicateCheck = true and send it to the device.
+     */
+    var saleRequest = new sdk.remotepay.SaleRequest();
+    saleRequest.setExternalId(clover.CloverID.getNewId());
+    saleRequest.setAmount(100);
+    saleRequest.disableDuplicateCheck = true;
+    this.displayMessage({message: "Sending sale", request: saleRequest});
+    this.cloverConnector.sale(saleRequest);
+};
+DisableDuplicateCheckExampleCloverConnectorListener.prototype.onSaleResponse = function (response) {
+    /*
+     The sale is complete.  It might be canceled, or successful.  This can be determined by the
+     values in the response.
+     */
+
+    this.displayMessage({message: "Sale response received", response: response});
+    if (!response.getIsSale()) {
+        // Exit if a sale did not process as expected
+        console.error("Response is not a sale!");
+        this.testComplete();
+        return;
+    }
+};
+
+/**
+ * Used in the test to help identify where messages come from.
+ * @returns {string}
+ */
+DisableDuplicateCheckExampleCloverConnectorListener.prototype.getTestName = function () {
+    return "Test the disableDuplicateCheck transaction setting";
+};
+
+/**
+ * A very simple subclass of the tests that specifies the listener (see above)
+ * that defines the test flow.
+ * @type {TestBase}
+ */
+var TestDisableDuplicateCheck = function (configUrl, friendlyName, progressinfoCallback) {
+    TestBase.call(this, configUrl, friendlyName, progressinfoCallback);
+};
+
+TestDisableDuplicateCheck.prototype = Object.create(TestBase.prototype);
+TestDisableDuplicateCheck.prototype.constructor = TestDisableDuplicateCheck;
+
+TestDisableDuplicateCheck.prototype.getCloverConnectorListener = function (cloverConnector) {
+    return new DisableDuplicateCheckExampleCloverConnectorListener(cloverConnector, this.progressinfoCallback);
+};
+
+/**
+ * Attach the test of a disableDuplicateCheck to the testbase to facilitate calling from the main page.
+ * @param configUrl
+ * @param progressinfoCallback
+ */
+TestBase.TestDisableDuplicateCheck = function(configUrl, configFile, progressinfoCallback) {
+    var testObj = new TestDisableDuplicateCheck(configUrl, configFile, progressinfoCallback);
+    testObj.test();
+};
+
+if ('undefined' !== typeof module) {
+    module.exports = TestDisableDuplicateCheck;
+}

--- a/public/js/tests/TestDisableDuplicateCheck.js
+++ b/public/js/tests/TestDisableDuplicateCheck.js
@@ -52,6 +52,11 @@ DisableDuplicateCheckExampleCloverConnectorListener.prototype.getTestName = func
     return "Test the disableDuplicateCheck transaction setting";
 };
 
+DisableDuplicateCheckExampleCloverConnectorListener.prototype.onConfirmPaymentRequest = function() {
+  // do nothing. override the ExampleCloverConnectorListener's behavior of automatically
+  // verifying all challenges.
+};
+
 /**
  * A very simple subclass of the tests that specifies the listener (see above)
  * that defines the test flow.


### PR DESCRIPTION
…action setting. Update README to include webpack command.

Because of the nature of disableDuplicateCheck, it will only fire on the second card transaction when the same card is used. As such, I was hoping to add a unit test that would automatically fire 2 transactions back-to-back by including code like this in the `DisableDuplicateCheckExampleCloverConnectorListener.prototype.onSaleResponse`:

```
    // since we are testing the disableDuplicateCheck transaction setting, we can't
    // see if it's accomplishing its intended behavior on the first sale.
    // therefore we need to start a new SaleRequest.
    if (this.hasCompletedFirstTransaction) {
      // Always call this when your test is done, or the device may fail to connect the
      // next time, because it is already connected.
      console.log("Finshing TestDisableDuplicateCheck");
      this.testComplete(response.getSuccess());
    } else {
      this.hasCompletedFirstTransaction = true;
      this.startTest();
    }
```

However, the listener's `CloverConnector` was not persisted across transactions, and the resulting error message was "Failed to pair this response:" fired in CloverConnector.#onFinishOk L1117.

So... for the time being, just run this unit test twice to ensure that the disableDuplicateCheck txaction setting is working as intended.
