### PR TITLE
Semi 1507

### DIFF
--- a/public/ts/test-src.ts
+++ b/public/ts/test-src.ts
@@ -18,6 +18,9 @@ import * as tests from './tests';
 // Remove the following to turn off logging.
 Clover.DebugConfig.loggingEnabled = true;
 
+let configLoader:CloverConfigLoader = null;
+var confignameeditor = null;
+
 export class ExampleWebsocketPairedCloverDeviceConfiguration extends Clover.WebSocketPairedCloverDeviceConfiguration {
     /**
      * @param rawConfiguration - a raw json object for initialization.
@@ -43,6 +46,9 @@ export class ExampleWebsocketPairedCloverDeviceConfiguration extends Clover.WebS
 
     public onPairingSuccess(authToken: string): void {
         console.log("Pairing succeeded, authToken is " + authToken);
+        this.setAuthToken(authToken);
+        configLoader.saveCloverConfig(confignameeditor.val(), this);
+        configLoader.getConfigsList();
         clearPairingCode();
     }
 }
@@ -85,7 +91,7 @@ let configuration: Clover.CloverDeviceConfiguration = new ExampleWebsocketPaired
 // Configuration persistence.
 // These examples use this path to persist.  This is part of the example 'server.js'
 const CONFIG_BASE_PATH = '../configuration/';
-let configLoader:CloverConfigLoader = new (class ExampleLoader extends URLCloverConfigLoader {
+configLoader = new (class ExampleLoader extends URLCloverConfigLoader {
 
     constructor() {
         super(CONFIG_BASE_PATH);
@@ -128,7 +134,7 @@ function clearPairingCode() {
     pairingCodeDisplay.text("  ");
 }
 
-var confignameeditor = $('<input type="text" id="confignameeditor" size="60">');
+confignameeditor = $('<input type="text" id="confignameeditor" size="60">');
 var configeditor = $('<textarea id="configeditor" style="margin: 0px; width: 882px; height: 193px;">');
 // Make the configuration select
 var configurationSelect = $('<select id="friendlyId" class="load-config-selector">');

--- a/public/ts/tests/TestCapturePreAuth.ts
+++ b/public/ts/tests/TestCapturePreAuth.ts
@@ -51,11 +51,14 @@ export namespace TestCapturePreAuth {
             /*
              The connector is ready, create a sale request and send it to the device.
              */
-            let request: sdk.remotepay.AuthRequest = new sdk.remotepay.AuthRequest();
+            /*
+             The connector is ready, create a sale request and send it to the device.
+             */
+            let request:sdk.remotepay.PreAuthRequest = new sdk.remotepay.PreAuthRequest();
             request.setExternalId(Clover.CloverID.getNewId());
             request.setAmount(10);
-            this.displayMessage({message: "Sending preauth", request: request});
-            this.cloverConnector.auth(request);
+            this.displayMessage({message: "Sending auth", request: request});
+            this.cloverConnector.preAuth(request);
         }
 
         public onPreAuthResponse(response:sdk.remotepay.PreAuthResponse) {

--- a/public/ts/tests/TestSaleWithOptions.ts
+++ b/public/ts/tests/TestSaleWithOptions.ts
@@ -91,6 +91,7 @@ export namespace TestSaleWithOptions {
             if (this.transactionSettings) {
                 for(let setting in this.transactionSettings) {
                     if (this.transactionSettings.hasOwnProperty(setting)) {
+                        // This does not work for "tipmode"
                         request['set' + setting.charAt(0).toUpperCase() + setting.slice(1)](this.transactionSettings[setting]);
                     }
                 }


### PR DESCRIPTION
#Change allows the authToken to be used/reused when using the Network Pay Display.

This means that the user will only need to enter the pairing code once per session, and even may be able to reuse it across sessions if no other attempt is made to connect to the device using the same configuration from another client.

This just makes testing faster, and tests the authToken functionality as well.

Requires 1.4.2 remote-pay-cloud
@david-clover-com 